### PR TITLE
grep: force sh to be used for fzf preview command

### DIFF
--- a/scripts/kks-grep
+++ b/scripts/kks-grep
@@ -11,7 +11,7 @@ history_file="$HOME/.cache/kks-grep-history"
 
 [ -f "$history_file" ] || touch "$history_file"
 
-rg --vimgrep '.+' "$@" |
+SHELL=sh rg --vimgrep '.+' "$@" |
 	fzf -d ':' --height 100% --prompt 'grep> ' --history="$history_file" \
 		--preview='range="$(echo {2}-5 | bc | sed "s/^-.*/0/"):$(echo {2}+20 | bc)"; bat -r "$range" -n --color always -H {2} {1}' |
 	awk -F':' '{print $1 " " "+" $2 ":" $3 }' |


### PR DESCRIPTION
Fixes kks-grep preview on non POSIX shells (Fish)

`$SHELL` variable is usually set to users preferred shell [1]. If set,
FZF uses the variable to run preview command. `kks-grep` preview command
requires POSIX compatible shell.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03