### PR TITLE
add git-like subcommand deferring mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ ENVIRONMENT VARIABLES
 Use "kks <command> -h" for command usage.
 ```
 
+### Unknown command
+
+When unknown command is run, `kks` will try to find an executable named
+`kks-<command>` in `$PATH`. If the executable is found, `kks` will run it
+with all arguments that were provided to the unknown command.
+ 
 ## Configuration
 
 `kks` can be configured through environment variables.

--- a/cmd/external.go
+++ b/cmd/external.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+func External(args []string, original error) error {
+	if len(args) == 0 {
+		return original
+	}
+
+	thisExecutable := filepath.Base(os.Args[0])
+	path, err := exec.LookPath(fmt.Sprintf("%s-%s", thisExecutable, args[0]))
+	if err != nil {
+		// no such executable - return original error
+		return original
+	}
+	if len(args) < 1 {
+		args = args[1:]
+	}
+
+	return syscall.Exec(path, args, os.Environ())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 )
 
 //go:embed embed/help
 var helpTxt string
+
+var UnknownSubcommand = errors.New("unknown subcommand")
 
 func Root(args []string) error {
 	if len(args) < 1 || args[0] == "-h" || args[0] == "--help" {
@@ -39,7 +42,7 @@ func Root(args []string) error {
 		}
 	}
 
-	return fmt.Errorf("unknown subcommand: %s", subcommand)
+	return fmt.Errorf("can't run %s: %w", subcommand, UnknownSubcommand)
 }
 
 func containsString(s []string, e string) bool {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -18,7 +19,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := cmd.Root(os.Args[1:]); err != nil {
+	err := cmd.Root(os.Args[1:])
+
+	if err != nil && errors.Is(err, cmd.UnknownSubcommand) {
+		err = cmd.External(os.Args[1:], err)
+	}
+	if err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
This commit implements a simple mechanism of deferring unknown
subcommands to other executables in `$PATH`.

When users executes `kks foo` kks will try to run `kks-foo` command.

Example:

```
$ cat ~/.local/bin/kks-date                                                                                                                                                                                  
#!/bin/sh
date $@
$ kks date -I
2021-11-12
$ kks grep
...
```

Just an idea, feel free to ignore if you don't like it (It can be implemented as wrapper script by user) :)