### PR TITLE
Fix get command on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [created]
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,9 @@ snapshot:
 changelog:
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^todo:"
+      - "^docs"
+      - "^test"
+      - "^todo"
+      - "^minor"
+      - "^WIP"
       - "typo"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ snapshot:
 changelog:
   filters:
     exclude:
-      - "^docs"
+      - "^doc"
       - "^test"
       - "^todo"
       - "^minor"

--- a/README.md
+++ b/README.md
@@ -101,8 +101,14 @@ COMMANDS
   init           print Kakoune definitions
 
 ENVIRONMENT VARIABLES
-  KKS_SESSION    Kakoune session
-  KKS_CLIENT     Kakoune client
+  KKS_SESSION
+      Kakoune session
+  KKS_CLIENT
+      Kakoune client
+  KKS_DEFAULT_SESSION
+      Session to try when KKS_SESSION is empty
+  KKS_USE_GITDIR_SESSIONS
+      If set, use git root dir name for creating/connecting to session
 
 Use "kks <command> -h" for command usage.
 ```

--- a/TODO
+++ b/TODO
@@ -1,5 +1,5 @@
-- [ ] add command to reset environment to kks-select script
-	- turns out there's no way in fzf to output some arbitrary line of text?
+- [x] add command to reset environment to kks-select script
+	- [x] turns out there's no way in fzf to output some arbitrary line of text?
 - [ ] add note about using 'kks edit' as EDITOR
 	- make a wrapper shell script "kks-edit" that exec 'kks edit $@'
 - [x] !!! use file path for git parsing instead of cwd

--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -38,7 +38,7 @@ func (c *CatCmd) Run() error {
 
 	sendCmd := fmt.Sprintf("write -force %s", tmp.Name())
 
-	if err := kak.Send(c.kctx, sendCmd); err != nil {
+	if err := kak.Send(c.kctx, sendCmd, nil); err != nil {
 		return err
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,10 @@ func (c *Cmd) Run() error      { return nil }
 func (c *Cmd) Name() string    { return c.fs.Name() }
 func (c *Cmd) Alias() []string { return c.alias }
 
+var noSessionErr = errors.New("no session in context")
+var noClientErr = errors.New("no client in context")
+var noBufferErr = errors.New("no buffer in context")
+
 func (c *Cmd) Init(args []string) error {
 	env := struct {
 		session           string
@@ -72,13 +76,13 @@ func (c *Cmd) Init(args []string) error {
 	}
 
 	if c.sessionReq && c.kctx.Session.Name == "" {
-		return errors.New("No session in context")
+		return noSessionErr
 	}
 	if c.clientReq && c.kctx.Client.Name == "" {
-		return errors.New("No client in context")
+		return noClientErr
 	}
 	if c.bufferReq && c.kctx.Buffer.Name == "" {
-		return errors.New("No buffer in context")
+		return noBufferErr
 	}
 
 	return nil

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -96,7 +96,7 @@ func connectOrEditInClient(c *EditCmd, fp *kak.Filepath) error {
 			sb.WriteString(fmt.Sprintf(" %d", fp.Column))
 		}
 
-		if err := kak.Send(c.kctx, sb.String()); err != nil {
+		if err := kak.Send(c.kctx, sb.String(), nil); err != nil {
 			return err
 		}
 	}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -52,7 +52,7 @@ func findOrRunSession(c *EditCmd, fp *kak.Filepath) error {
 				if err != nil {
 					return err
 				}
-				fmt.Println("New session for git directory started:", sessionName)
+				fmt.Println("new session for git directory started:", sessionName)
 			}
 		}
 	}

--- a/cmd/embed/help
+++ b/cmd/embed/help
@@ -16,8 +16,14 @@ COMMANDS
   init           print Kakoune definitions
 
 ENVIRONMENT VARIABLES
-  KKS_SESSION    Kakoune session
-  KKS_CLIENT     Kakoune client
+  KKS_SESSION
+      Kakoune session
+  KKS_CLIENT
+      Kakoune client
+  KKS_DEFAULT_SESSION
+      Session to try when KKS_SESSION is empty
+  KKS_USE_GITDIR_SESSIONS
+      If set, use git root dir name for creating/connecting to session
 
 FLAGS
   -v             print version

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kkga/kks/kak"
 )
 
+const kakEchoErrPrefix = "__kak_error__"
+
 func NewGetCmd() *GetCmd {
 	c := &GetCmd{Cmd: Cmd{
 		fs:         flag.NewFlagSet("get", flag.ExitOnError),
@@ -49,8 +51,8 @@ func (c *GetCmd) Run() error {
 		return err
 	}
 
-	if strings.HasPrefix(resp, "__kak_error__") {
-		kakOutErr := strings.TrimPrefix(resp, "__kak_error__")
+	if strings.HasPrefix(resp, kakEchoErrPrefix) {
+		kakOutErr := strings.TrimPrefix(resp, kakEchoErrPrefix)
 		kakOutErr = strings.TrimSpace(kakOutErr)
 		return &kakErr{kakOutErr}
 	}
@@ -64,7 +66,6 @@ func (c *GetCmd) Run() error {
 		}
 
 		fmt.Println(strings.Join(ss, "\n"))
-
 	}
 
 	return nil

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,6 +29,14 @@ type GetCmd struct {
 	raw bool
 }
 
+type kakErr struct {
+	err string
+}
+
+func (e *kakErr) Error() string {
+	return fmt.Sprintf("kak_error: %s", e.err)
+}
+
 func (c *GetCmd) Run() error {
 	query := c.fs.Arg(0)
 	if query == "" {
@@ -39,6 +47,12 @@ func (c *GetCmd) Run() error {
 	resp, err := kak.Get(c.kctx, query)
 	if err != nil {
 		return err
+	}
+
+	if strings.HasPrefix(resp, "__kak_error__") {
+		kakOutErr := strings.TrimPrefix(resp, "__kak_error__")
+		kakOutErr = strings.TrimSpace(kakOutErr)
+		return &kakErr{kakOutErr}
 	}
 
 	if c.raw {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -9,8 +9,6 @@ import (
 	"github.com/kkga/kks/kak"
 )
 
-const kakEchoErrPrefix = "__kak_error__"
-
 func NewGetCmd() *GetCmd {
 	c := &GetCmd{Cmd: Cmd{
 		fs:         flag.NewFlagSet("get", flag.ExitOnError),
@@ -51,8 +49,8 @@ func (c *GetCmd) Run() error {
 		return err
 	}
 
-	if strings.HasPrefix(resp, kakEchoErrPrefix) {
-		kakOutErr := strings.TrimPrefix(resp, kakEchoErrPrefix)
+	if strings.HasPrefix(resp, kak.EchoErrPrefix) {
+		kakOutErr := strings.TrimPrefix(resp, kak.EchoErrPrefix)
 		kakOutErr = strings.TrimSpace(kakOutErr)
 		return &kakErr{kakOutErr}
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -16,17 +16,17 @@ func NewGetCmd() *GetCmd {
 		shortDesc:  "Get states from Kakoune context.",
 		usageLine:  "[options] (<%val{..}> | <%opt{..}> | <%reg{..}> | <%sh{..}>)",
 		sessionReq: true,
-		// TODO maybe actually just use flags for args
-		// or maybe create separate subcommands get-val, etc
 	}}
 	c.fs.StringVar(&c.session, "s", "", "session")
 	c.fs.StringVar(&c.client, "c", "", "client")
 	c.fs.StringVar(&c.buffer, "b", "", "buffer")
+	c.fs.BoolVar(&c.raw, "R", false, "raw output")
 	return c
 }
 
 type GetCmd struct {
 	Cmd
+	raw bool
 }
 
 func (c *GetCmd) Run() error {
@@ -41,7 +41,17 @@ func (c *GetCmd) Run() error {
 		return err
 	}
 
-	fmt.Println(strings.Join(resp, "\n"))
+	if c.raw {
+		fmt.Println(resp)
+	} else {
+		ss := strings.Split(resp, "' '")
+		for i, val := range ss {
+			ss[i] = strings.Trim(val, "'")
+		}
+
+		fmt.Println(strings.Join(ss, "\n"))
+
+	}
 
 	return nil
 }

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -37,13 +37,13 @@ func (c *KillCmd) Run() error {
 				Client:  c.kctx.Client,
 				Buffer:  c.kctx.Buffer,
 			}
-			if err := kak.Send(sessCtx, sendCmd); err != nil {
+			if err := kak.Send(sessCtx, sendCmd, nil); err != nil {
 				return err
 			}
 		}
 	} else {
-		// TODO need to somehow trigger "no session" err
-		if err := kak.Send(c.kctx, sendCmd); err != nil {
+		// TODO check for context session
+		if err := kak.Send(c.kctx, sendCmd, nil); err != nil {
 			return err
 		}
 	}

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -13,20 +13,20 @@ func NewKillCmd() *KillCmd {
 		shortDesc: "Terminate Kakoune session.",
 		usageLine: "[options]",
 	}}
+	c.fs.BoolVar(&c.all, "a", false, "all sessions")
 	c.fs.StringVar(&c.session, "s", "", "session")
-	c.fs.BoolVar(&c.allSessions, "a", false, "all sessions")
 	return c
 }
 
 type KillCmd struct {
 	Cmd
-	allSessions bool
+	all bool
 }
 
 func (c *KillCmd) Run() error {
 	sendCmd := "kill"
 
-	if c.allSessions {
+	if c.all {
 		sessions, err := kak.Sessions()
 		if err != nil {
 			return err
@@ -42,7 +42,9 @@ func (c *KillCmd) Run() error {
 			}
 		}
 	} else {
-		// TODO check for context session
+		if c.kctx.Session.Name == "" {
+			return noSessionErr
+		}
 		if err := kak.Send(c.kctx, sendCmd, nil); err != nil {
 			return err
 		}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -27,7 +27,6 @@ type SendCmd struct {
 }
 
 func (c *SendCmd) Run() error {
-	// TODO probably need to do some shell escaping here
 	sendCmd := strings.Join(c.fs.Args(), " ")
 
 	if c.allClients {
@@ -39,7 +38,7 @@ func (c *SendCmd) Run() error {
 			clients, err := s.Clients()
 			for _, c := range clients {
 				clientCtx := &kak.Context{Session: s, Client: c}
-				if err := kak.Send(clientCtx, sendCmd); err != nil {
+				if err := kak.Send(clientCtx, sendCmd, nil); err != nil {
 					return err
 				}
 			}
@@ -48,8 +47,8 @@ func (c *SendCmd) Run() error {
 			}
 		}
 	} else {
-		// TODO: need to trigger "session not set" error
-		if err := kak.Send(c.kctx, sendCmd); err != nil {
+		// TODO check for context session
+		if err := kak.Send(c.kctx, sendCmd, nil); err != nil {
 			return err
 		}
 	}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -14,7 +14,7 @@ func NewSendCmd() *SendCmd {
 		shortDesc: "Send commands to Kakoune context.",
 		usageLine: "[options] <command>",
 	}}
-	c.fs.BoolVar(&c.all, "a", false, "send to all sessions and clients")
+	c.fs.BoolVar(&c.all, "a", false, "all sessions and clients")
 	c.fs.StringVar(&c.session, "s", "", "session")
 	c.fs.StringVar(&c.client, "c", "", "client")
 	c.fs.StringVar(&c.buffer, "b", "", "buffer")

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -14,7 +14,7 @@ func NewSendCmd() *SendCmd {
 		shortDesc: "Send commands to Kakoune context.",
 		usageLine: "[options] <command>",
 	}}
-	c.fs.BoolVar(&c.allClients, "a", false, "send to all clients")
+	c.fs.BoolVar(&c.all, "a", false, "send to all sessions and clients")
 	c.fs.StringVar(&c.session, "s", "", "session")
 	c.fs.StringVar(&c.client, "c", "", "client")
 	c.fs.StringVar(&c.buffer, "b", "", "buffer")
@@ -23,13 +23,13 @@ func NewSendCmd() *SendCmd {
 
 type SendCmd struct {
 	Cmd
-	allClients bool
+	all bool
 }
 
 func (c *SendCmd) Run() error {
 	sendCmd := strings.Join(c.fs.Args(), " ")
 
-	if c.allClients {
+	if c.all {
 		sessions, err := kak.Sessions()
 		if err != nil {
 			return err
@@ -47,7 +47,9 @@ func (c *SendCmd) Run() error {
 			}
 		}
 	} else {
-		// TODO check for context session
+		if c.kctx.Session.Name == "" {
+			return noSessionErr
+		}
 		if err := kak.Send(c.kctx, sendCmd, nil); err != nil {
 			return err
 		}

--- a/kak/get.go
+++ b/kak/get.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const kakEchoPrefix = "__kak_echo__"
+
 func Get(kctx *Context, query string) (string, error) {
 	// create a tmp file for kak to echo the value
 	tmp, err := ioutil.TempFile("", "kks-tmp")
@@ -19,8 +21,8 @@ func Get(kctx *Context, query string) (string, error) {
 	go ReadTmp(tmp, ch)
 
 	// tell kak to echo the requested state
-	// the '__kakEcho__' is there to ensure that file gets written even if kak's echo is empty
-	sendCmd := fmt.Sprintf("echo -quoting kakoune -to-file %s %%{ __kakEcho__ %s }", tmp.Name(), query)
+	// the '__kak_echo__' is there to ensure that file gets written even kak's echo is empty
+	sendCmd := fmt.Sprintf("echo -quoting kakoune -to-file %s %%{ %s %s }", tmp.Name(), kakEchoPrefix, query)
 	if err := Send(kctx, sendCmd, tmp); err != nil {
 		return "", err
 	}
@@ -28,7 +30,7 @@ func Get(kctx *Context, query string) (string, error) {
 	// wait until tmp file is populated and read
 	output := <-ch
 
-	output = strings.TrimPrefix(output, "'__kakEcho__'")
+	output = strings.TrimPrefix(output, fmt.Sprintf("'%s'", kakEchoPrefix))
 	output = strings.TrimSpace(output)
 
 	tmp.Close()

--- a/kak/get.go
+++ b/kak/get.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 )
 
-const kakEchoPrefix = "__kak_echo__"
+// EchoPrefix is a prefix added to Kakoune's echo output
+const EchoPrefix = "__kak_echo__"
+
+// EchoErrPrefix is a prefix added when Kakoune's evaluation catches an error
+const EchoErrPrefix = "__kak_error__"
 
 func Get(kctx *Context, query string) (string, error) {
 	// create a tmp file for kak to echo the value
@@ -22,7 +26,7 @@ func Get(kctx *Context, query string) (string, error) {
 
 	// tell kak to echo the requested state
 	// the '__kak_echo__' is there to ensure that file gets written even kak's echo is empty
-	sendCmd := fmt.Sprintf("echo -quoting kakoune -to-file %s %%{ %s %s }", tmp.Name(), kakEchoPrefix, query)
+	sendCmd := fmt.Sprintf("echo -quoting kakoune -to-file %s %%{ %s %s }", tmp.Name(), EchoPrefix, query)
 	if err := Send(kctx, sendCmd, tmp); err != nil {
 		return "", err
 	}
@@ -30,7 +34,7 @@ func Get(kctx *Context, query string) (string, error) {
 	// wait until tmp file is populated and read
 	output := <-ch
 
-	output = strings.TrimPrefix(output, fmt.Sprintf("'%s'", kakEchoPrefix))
+	output = strings.TrimPrefix(output, fmt.Sprintf("'%s'", EchoPrefix))
 	output = strings.TrimSpace(output)
 
 	tmp.Close()

--- a/kak/kak.go
+++ b/kak/kak.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"os/exec"
+	"strings"
 )
 
 type Context struct {
@@ -32,17 +33,31 @@ func (s *Session) Exists() (exists bool, err error) {
 
 func (s *Session) Dir() (dir string, err error) {
 	sessCtx := &Context{Session: *s}
-	v, err := Get(sessCtx, "%sh{pwd}")
-	dir = v[0]
+	resp, err := Get(sessCtx, "%sh{pwd}")
+	if err != nil {
+		return "", err
+	}
+
+	dir = strings.Trim(resp, "'")
 	return
 }
 
 func (s *Session) Clients() (clients []Client, err error) {
 	sessCtx := &Context{Session: *s}
-	cl, err := Get(sessCtx, "%val{client_list}")
-	for _, c := range cl {
+	resp, err := Get(sessCtx, "%val{client_list}")
+	if err != nil {
+		return nil, err
+	}
+
+	ss := strings.Split(resp, "' '")
+	for i, val := range ss {
+		ss[i] = strings.Trim(val, "'")
+	}
+
+	for _, c := range ss {
 		clients = append(clients, Client{c})
 	}
+
 	return
 }
 

--- a/kak/kak_test.go
+++ b/kak/kak_test.go
@@ -35,9 +35,9 @@ func TestSessionDir(t *testing.T) {
 			kctx := &Context{}
 			kctx.Session = Session{testSession}
 
-			defer Send(kctx, "kill")
+			defer Send(kctx, "kill", nil)
 
-			if err := Send(kctx, fmt.Sprintf("cd %s", tt.kakdir)); err != nil {
+			if err := Send(kctx, fmt.Sprintf("cd %s", tt.kakdir), nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -76,7 +76,7 @@ func TestSessionExists(t *testing.T) {
 			}
 			kctx := &Context{}
 			kctx.Session = tt.session
-			defer Send(kctx, "kill")
+			defer Send(kctx, "kill", nil)
 
 			got, err := kctx.Session.Exists()
 			if err != nil {

--- a/kak/send.go
+++ b/kak/send.go
@@ -3,30 +3,49 @@ package kak
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 )
 
-func Send(kctx *Context, command string) error {
+func Send(kctx *Context, kakCommand string, errOutFile *os.File) error {
 	kakExec, err := kakExec()
 	if err != nil {
 		return err
 	}
 	cmd := exec.Command(kakExec, "-p", kctx.Session.Name)
-	// cmd.Stdout = os.Stdout
-	// cmd.Stderr = os.Stderr
 
 	stdin, err := cmd.StdinPipe()
 
 	go func() {
-		io.WriteString(stdin, "evaluate-commands")
-
+		// kak try
+		io.WriteString(stdin, "try %{ ")
+		io.WriteString(stdin, "eval ")
 		if kctx.Buffer.Name != "" {
-			io.WriteString(stdin, fmt.Sprintf(" -buffer %s", kctx.Buffer.Name))
+			io.WriteString(stdin, fmt.Sprintf("-buffer %s ", kctx.Buffer.Name))
 		} else if kctx.Client.Name != "" {
-			io.WriteString(stdin, fmt.Sprintf(" -try-client %s", kctx.Client.Name))
+			io.WriteString(stdin, fmt.Sprintf("-try-client %s ", kctx.Client.Name))
 		}
 
-		io.WriteString(stdin, fmt.Sprintf(" %s", command))
+		io.WriteString(stdin, fmt.Sprintf("%s ", kakCommand))
+		io.WriteString(stdin, "}")
+
+		// kak catch
+		io.WriteString(stdin, "catch %{ ")
+		io.WriteString(stdin, "echo -debug kks: %val{error} ")
+		io.WriteString(stdin, "\n")
+		if errOutFile != nil {
+			// write a prefixed error to tmp file so that we can parse it in runner and decide what to do
+			io.WriteString(stdin, fmt.Sprintf("echo -to-file %s __kak_error__ %%val{error} ", errOutFile.Name()))
+			io.WriteString(stdin, "\n")
+		}
+		io.WriteString(stdin, "eval ")
+		if kctx.Buffer.Name != "" {
+			io.WriteString(stdin, fmt.Sprintf("-buffer %s ", kctx.Buffer.Name))
+		} else if kctx.Client.Name != "" {
+			io.WriteString(stdin, fmt.Sprintf("-try-client %s ", kctx.Client.Name))
+		}
+		io.WriteString(stdin, "%{ echo -markup {Error}kks: %val{error} } ")
+		io.WriteString(stdin, "}")
 
 		stdin.Close()
 	}()
@@ -35,5 +54,6 @@ func Send(kctx *Context, command string) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
fixes #10 

Additionally, the `get` command:
- now has an `-R` flag to print out raw Kakoune-quoted output
- prints Kakoune's errors to stderr