### PR TITLE
check scanner for error

### DIFF
--- a/kak/kak.go
+++ b/kak/kak.go
@@ -67,7 +67,7 @@ func Sessions() (sessions []Session, err error) {
 		return
 	}
 
-	err = clearSessions()
+	err = exec.Command(kakExec, "-clear").Run()
 	if err != nil {
 		return
 	}
@@ -82,20 +82,6 @@ func Sessions() (sessions []Session, err error) {
 	}
 
 	return sessions, scanner.Err()
-}
-
-func clearSessions() error {
-	kakExec, err := kakExec()
-	if err != nil {
-		return err
-	}
-
-	err = exec.Command(kakExec, "-clear").Run()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func kakExec() (kakExec string, err error) {

--- a/kak/kak.go
+++ b/kak/kak.go
@@ -81,7 +81,7 @@ func Sessions() (sessions []Session, err error) {
 		}
 	}
 
-	return
+	return sessions, scanner.Err()
 }
 
 func clearSessions() error {


### PR DESCRIPTION
It's considered a good practice to check for scanner's error. Also I allowed to myself to dismiss the `clearSessions` func, as it's called from single place only where `kakExec` is already available.