### PR TITLE
fix: escape whitespace in filename

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -87,7 +87,7 @@ func connectOrEditInClient(c *EditCmd, fp *kak.Filepath) error {
 	} else {
 		// if client set, send 'edit [file]' to client
 		sb := strings.Builder{}
-		sb.WriteString(fmt.Sprintf("edit -existing %s", fp.Name))
+		sb.WriteString(fmt.Sprintf("edit -existing %s", strings.ReplaceAll(fp.Name, " ", "\\\\ ")))
 		if fp.Line != 0 {
 			sb.WriteString(fmt.Sprintf(" %d", fp.Line))
 		}

--- a/kak/send.go
+++ b/kak/send.go
@@ -27,7 +27,7 @@ func Send(kctx *Context, kakCommand string, errOutFile *os.File) error {
 	sb.WriteString("try %{")
 	sb.WriteString(" eval")
 	if kctx.Buffer.Name != "" {
-		sb.WriteString(fmt.Sprintf(" -buffer %s", kctx.Buffer.Name))
+		sb.WriteString(fmt.Sprintf(" -buffer %s", strings.ReplaceAll(kctx.Buffer.Name, " ", "\\ ")))
 	} else if kctx.Client.Name != "" {
 		sb.WriteString(fmt.Sprintf(" -try-client %s", kctx.Client.Name))
 	}


### PR DESCRIPTION
When opening a file containing whitespace, the file name needs to have an additional double backslash added.

### TODOs

* [x] buffer
* [x] cat

For kks-buffer script, I've changed the script to

https://github.com/Yukaii/dotfiles/blob/ec80442b44c718bd5100163618e20c7441385ccb/bin/.bin/kks-buffers#L21-L24

```
#!/bin/sh
#
# pick buffers
#
# requires:
# - fzf (https://github.com/junegunn/fzf)
# - bat (change to your liking) (https://github.com/sharkdp/bat)

preview_cmd="bat --color=always --line-range=:500"
history_file="$HOME/.cache/kks-buffers-history"

[ -f "$history_file" ] || touch "$history_file"

kks get '%val{buflist}' |
	grep -F "$*" |
	fzf --height 100% --highlight-line --prompt 'buf> ' --preview "kks cat -b {} | $preview_cmd" \
		--header="[c-x] delete, [c-t] new scratch" \
		--bind="ctrl-x:execute-silent(kks send -b {} delete-buffer)+reload(kks get '%val{buflist}')" \
		--bind="ctrl-t:execute-silent(kks send edit -scratch {q})+reload(kks get '%val{buflist}')" \
		--history="$history_file" |
	while read -r name; do
    escaped_name=$(printf "'%s'" "$(echo "$name" | sed 's/ /\\ /g')")
    kks send buffer "$escaped_name"
	done

```